### PR TITLE
Type mismatch with current LUFA

### DIFF
--- a/src/Descriptors.c
+++ b/src/Descriptors.c
@@ -202,7 +202,7 @@ const USB_Descriptor_String_t PROGMEM ProductString = USB_STRING_DESCRIPTOR(L"Li
  *  USB host.
  */
 uint16_t CALLBACK_USB_GetDescriptor(const uint16_t wValue,
-                                    const uint8_t wIndex,
+                                    const uint16_t wIndex,
                                     const void** const DescriptorAddress)
 {
   const uint8_t  DescriptorType   = (wValue >> 8);

--- a/src/Descriptors.h
+++ b/src/Descriptors.h
@@ -82,7 +82,7 @@ enum StringDescriptors_t
 
 /* Function Prototypes: */
 uint16_t CALLBACK_USB_GetDescriptor(const uint16_t wValue,
-                                    const uint8_t wIndex,
+                                    const uint16_t wIndex,
                                     const void** const DescriptorAddress)
   ATTR_WARN_UNUSED_RESULT ATTR_NON_NULL_PTR_ARG(3);
 


### PR DESCRIPTION
The code doesn't compile with the current version of LUFA, but with touchups of the declarations of CALLBACK_USB_GetDescriptor it does. Patch attached. (I haven't actually run the code yet, some hardware work left to do.) 
[lufa-types.patch.txt](https://github.com/MMcM/lmkbd2/files/1541904/lufa-types.patch.txt)
